### PR TITLE
Use float instead of string for penalizing coefficient

### DIFF
--- a/bgbb_airflow/fit_airflow_job.py
+++ b/bgbb_airflow/fit_airflow_job.py
@@ -93,7 +93,7 @@ def save(submission_date, bucket, prefix, params_df):
     help="List of integer sample ids or None",
 )
 @click.option("--sample-fraction", type=float, default=0.1)
-@click.option("--penalizer-coef", type=str, default=0.01)
+@click.option("--penalizer-coef", type=float, default=0.01)
 @click.option(
     "--bucket", type=str, default="net-mozaws-prod-us-west-2-pipeline-analysis"
 )


### PR DESCRIPTION
```
/databricks/python/lib/python3.5/site-packages/bgbb_airflow/fit_airflow_job.py in main(submission_date, model_win, start_params, sample_ids, sample_fraction, penalizer_coef, bucket, prefix)
    122     )
    123     df2 = transform(
--> 124         df, spark, penalizer_coef=penalizer_coef, start_params=start_params
    125     )
    126     save(submission_date, bucket, prefix, df2)

/databricks/python/lib/python3.5/site-packages/bgbb_airflow/fit_airflow_job.py in transform(df, spark, penalizer_coef, start_params)
     64         params=start_params,
     65     )
---> 66     bg.rfn.fit(df)
     67     params_df = spark.createDataFrame(
     68         pd.DataFrame({k: [v] for k, v in bg.params_.items()})

/databricks/python/lib/python3.5/site-packages/bgbb/wrappers.py in fit(self, df, **kw)
     76             print("Warning: no n_custs column")
     77             n_custs = np.ones_like(frequency)
---> 78         return self.mod.fit(frequency, recency, n, n_custs, **kw)
     79 
     80     @wraps(BetaGeoBetaBinomFitter._loglikelihood)

/databricks/python/lib/python3.5/site-packages/lifetimes/fitters/beta_geo_beta_binom_fitter.py in fit(self, frequency, recency, n, n_custs, verbose, tol, iterative_fitting, index, fit_method, maxiter, initial_params, **kwargs)
    151             fit_method,
    152             maxiter,
--> 153             **kwargs)
    154         self.params_ = OrderedDict(zip(['alpha', 'beta', 'gamma', 'delta'],
    155                                        params))

/databricks/python/lib/python3.5/site-packages/lifetimes/utils.py in _fit(minimizing_function, minimizing_function_args, iterative_fitting, initial_params, params_size, disp, tol, fit_method, maxiter, **kwargs)
    323                           x0=current_init_params,
    324                           args=(minimizing_function_args, minimizing_function),
--> 325                           options=minimize_options)
    326         sols.append(output.x)[0m
    327         ll.append(output.fun)

/databricks/python/lib/python3.5/site-packages/scipy/optimize/_minimize.py in minimize(fun, x0, args, method, jac, hess, hessp, bounds, constraints, tol, callback, options)
    436                       callback=callback, **options)
    437     elif meth == 'nelder-mead':
--> 438         return _minimize_neldermead(fun, x0, args, callback, **options)
    439     elif meth == 'powell':
    440         return _minimize_powell(fun, x0, args, callback, **options)

/databricks/python/lib/python3.5/site-packages/scipy/optimize/optimize.py in _minimize_neldermead(func, x0, args, callback, maxiter, maxfev, disp, return_all, initial_simplex, xatol, fatol, **unknown_options)
    515 
    516     for k in range(N + 1):
--> 517         fsim[k] = func(sim[k])
    518 
    519     ind = numpy.argsort(fsim)

/databricks/python/lib/python3.5/site-packages/scipy/optimize/optimize.py in function_wrapper(*wrapper_args)
    290     def function_wrapper(*wrapper_args):
    291         ncalls[0] += 1
--> 292         return function(*(wrapper_args + args))
    293 
    294     return ncalls, function_wrapper

/databricks/python/lib/python3.5/site-packages/lifetimes/utils.py in _func_caller(params, func_args, function)
    299 
    300     def _func_caller(params, func_args, function):
--> 301         return function(params, *func_args)
    302 
    303     if iterative_fitting <= 0:

/databricks/python/lib/python3.5/site-packages/bgbb/core.py in _negative_log_likelihood(cls, params, frequency, recency, n, n_custs, penalizer_coef)
     51                 cls._loglikelihood(params, frequency, recency, n) * n_custs
     52             )
---> 53             + penalizer_term
     54         )
     55 

TypeError: ufunc 'add' did not contain a loop with signature matching types dtype('<U32') dtype('<U32') dtype('<U32')
```
````