### PR TITLE
Cast dates to string to keep schema compatibility

### DIFF
--- a/bgbb_airflow/fit_airflow_job.py
+++ b/bgbb_airflow/fit_airflow_job.py
@@ -123,6 +123,7 @@ def main(
 ):
     print(f"Running param fitting. bgbb_airflow version {bgbb_airflow.__version__}")
     spark = SparkSession.builder.getOrCreate()
+    spark.conf.set("spark.sql.execution.arrow.enabled", "true")
     ho_start = pd.to_datetime(submission_date).strftime(S3_DAY_FMT_DASH)
 
     df, _ = extract(

--- a/bgbb_airflow/pred_airflow_job.py
+++ b/bgbb_airflow/pred_airflow_job.py
@@ -173,6 +173,7 @@ def main(
     view_materialization_dataset,
 ):
     spark = SparkSession.builder.getOrCreate()
+    spark.conf.set("spark.sql.execution.arrow.enabled", "true")
     print(
         f"Generating predictions with bgbb_airflow version {bgbb_airflow.__version__}"
     )

--- a/bgbb_airflow/sql_utils.py
+++ b/bgbb_airflow/sql_utils.py
@@ -141,7 +141,7 @@ def extract_view_bigquery(
     query = f"""
     SELECT
         client_id
-        , submission_date
+        , CAST(submission_date as STRING) as submission_date
         , sample_id
         {first_dims_agg}
     FROM

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from pytest import fixture
 @fixture
 def spark():
     spark = pyspark.sql.SparkSession.builder.appName("test").getOrCreate()
+    spark.conf.set("spark.sql.execution.arrow.enabled", "true")
     yield spark
     spark.stop()
 


### PR DESCRIPTION

The original schema calls for max_day and min_day to be STRING instead of dates. This is causing issues in Airflow when writing out data to parquet.

> [2019-12-01 03:54:48,448] {logging_mixin.py:95} INFO - [2019-12-01 03:54:48,448] {pod_launcher.py:104} INFO - 2019-12-01 03:54:48,423 root ERROR Process-7: exception 400 Error while reading data, error message: incompatible types for field 'max_day': INT32(DATE) in Parquet vs. string in schema. Notifying main process to handle

https://workflow.telemetry.mozilla.org/log?task_id=bigquery_load&dag_id=main_summary.bgbb_pred_bigquery_load&execution_date=2019-11-30T01%3A00%3A00%2B00%3A00

```
spark.read.parquet("gs://amiyaguchi-dev/bgbb-ref/active_profiles/v1/submission_date_s3=2019-10-01/").printSchema()

root
 |-- client_id: string (nullable = true)
 |-- recency: integer (nullable = true)
 |-- frequency: long (nullable = true)
 |-- num_opportunities: integer (nullable = true)
 |-- max_day: string (nullable = true)
 |-- min_day: string (nullable = true)
 |-- locale: string (nullable = true)
 |-- normalized_channel: string (nullable = true)
....

spark.read.parquet("gs://amiyaguchi-dev/bgbb/active_profiles/v1/submission_date_s3=2019-11-01/").printSchema()

root
 |-- client_id: string (nullable = true)
 |-- recency: integer (nullable = true)
 |-- frequency: long (nullable = true)
 |-- num_opportunities: integer (nullable = true)
 |-- max_day: date (nullable = true)
 |-- min_day: date (nullable = true)
 |-- locale: string (nullable = true)
 |-- normalized_channel: string (nullable = true)
....

spark.read.parquet("gs://amiyaguchi-dev/bgbb/active_profiles/v1/submission_date_s3=2019-11-02/").printSchema()

root
 |-- client_id: string (nullable = true)
 |-- recency: integer (nullable = true)
 |-- frequency: long (nullable = true)
 |-- num_opportunities: integer (nullable = true)
 |-- max_day: string (nullable = true)
 |-- min_day: string (nullable = true)
 |-- locale: string (nullable = true)
 |-- normalized_channel: string (nullable = true)
....
```

There is also an issue of serialization of a column that may or may not be related:

> : org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 6.0 failed 4 times, most recent failure: Lost task 0.3 in stage 6.0 (TID 1371, bgbb-pred-20191130-w-9.c.airflow-dataproc.internal, executor 22): java.lang.UnsupportedOperationException: org.apache.parquet.column.values.dictionary.PlainValuesDictionary$PlainIntegerDictionary

https://console.cloud.google.com/dataproc/jobs/bgbb_pred_dataproc_417dfa28?project=airflow-dataproc&region=global